### PR TITLE
App via hemskärm

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev --turbopack",
-    "build": "next build --turbopack",
+    "dev": "next dev",
+    "build": "next build",
     "start": "next start",
     "lint": "eslint"
   },

--- a/src/app/ClientErrorReporter.tsx
+++ b/src/app/ClientErrorReporter.tsx
@@ -1,0 +1,76 @@
+"use client";
+
+type ClientErrorPayload = {
+  kind: "error" | "unhandledrejection";
+  message: string;
+  stack?: string;
+  href?: string;
+  userAgent?: string;
+  time: string;
+};
+
+function postClientError(payload: ClientErrorPayload) {
+  try {
+    const body = JSON.stringify(payload);
+    // Prefer sendBeacon (more reliable during crashes/navigation).
+    if (typeof navigator !== "undefined" && "sendBeacon" in navigator) {
+      const blob = new Blob([body], { type: "application/json" });
+      (navigator as Navigator).sendBeacon("/api/client-error", blob);
+      return;
+    }
+    void fetch("/api/client-error", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body,
+      keepalive: true,
+    });
+  } catch {
+    // Never throw from error reporting.
+  }
+}
+
+export function ClientErrorReporter() {
+  if (typeof window === "undefined") return null;
+
+  // Only register once per page lifetime.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const w = window as any;
+  if (w.__clientErrorReporterInstalled) return null;
+  w.__clientErrorReporterInstalled = true;
+
+  const base = (): Pick<ClientErrorPayload, "href" | "userAgent" | "time"> => ({
+    href: window.location.href,
+    userAgent: navigator.userAgent,
+    time: new Date().toISOString(),
+  });
+
+  window.addEventListener("error", (event) => {
+    const err = event.error as Error | undefined;
+    postClientError({
+      kind: "error",
+      message: err?.message ?? event.message ?? "Unknown error",
+      stack: err?.stack,
+      ...base(),
+    });
+  });
+
+  window.addEventListener("unhandledrejection", (event) => {
+    const reason = event.reason;
+    const message =
+      reason instanceof Error
+        ? reason.message
+        : typeof reason === "string"
+          ? reason
+          : "Unhandled promise rejection";
+    const stack = reason instanceof Error ? reason.stack : undefined;
+    postClientError({
+      kind: "unhandledrejection",
+      message,
+      stack,
+      ...base(),
+    });
+  });
+
+  return null;
+}
+

--- a/src/app/api/client-error/route.ts
+++ b/src/app/api/client-error/route.ts
@@ -1,0 +1,14 @@
+import { NextResponse } from "next/server";
+
+export async function POST(req: Request) {
+  try {
+    const payload = await req.json();
+    // Server-side log: shows up in hosting logs.
+    console.error("[client-error]", payload);
+  } catch (e) {
+    console.error("[client-error] Failed to parse payload", e);
+  }
+
+  return NextResponse.json({ ok: true });
+}
+

--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import { useEffect } from "react";
+
+export default function ErrorPage({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    // Keep a local console trace as well.
+    console.error("App error boundary caught:", error);
+  }, [error]);
+
+  return (
+    <main className="min-h-screen p-6 flex items-center justify-center">
+      <div className="max-w-md w-full rounded-xl border border-black/10 dark:border-white/15 p-5">
+        <h1 className="text-lg font-semibold">Något gick fel</h1>
+        <p className="mt-2 text-sm opacity-80">
+          Prova att ladda om. Om felet kvarstår är det sannolikt en bugg i
+          klienten.
+        </p>
+        {error.digest ? (
+          <p className="mt-2 text-xs opacity-70">Digest: {error.digest}</p>
+        ) : null}
+        <div className="mt-4 flex gap-3">
+          <button
+            className="rounded-md bg-black text-white dark:bg-white dark:text-black px-3 py-2 text-sm"
+            onClick={() => reset()}
+          >
+            Försök igen
+          </button>
+          <button
+            className="rounded-md border border-black/10 dark:border-white/15 px-3 py-2 text-sm"
+            onClick={() => window.location.reload()}
+          >
+            Ladda om
+          </button>
+        </div>
+      </div>
+    </main>
+  );
+}
+

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
+import { ClientErrorReporter } from "./ClientErrorReporter";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -27,6 +28,7 @@ export default function RootLayout({
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
+        <ClientErrorReporter />
         {children}
       </body>
     </html>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,5 +23,5 @@
     }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules", "cartwitness/**"]
 }


### PR DESCRIPTION
Implement global client-side error reporting and an error boundary, and disable Turbopack, to diagnose and mitigate crashes in iOS PWA mode.

The app is crashing when opened via the home screen on iOS, a scenario difficult to reproduce locally. This PR introduces a global client-side error reporter to capture detailed stack traces from user devices, adds a user-friendly error boundary, and disables Turbopack to avoid potential WebKit compatibility issues. Additionally, it fixes build errors by excluding the `cartwitness` subproject from the root `tsconfig.json`.

---
<a href="https://cursor.com/background-agent?bcId=bc-9bebe173-e836-46d3-a14f-e453ec46203f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-9bebe173-e836-46d3-a14f-e453ec46203f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

